### PR TITLE
Fix dependencies and add support for attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pom.xml
 <dependency>
     <groupId>org.phoebus</groupId>
     <artifactId>olog-email-notifier-module</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1.0</version>
 </dependency>
 <dependency>
     <groupId>jakarta.activation</groupId>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Phoebus Olog Email Notifier Module
 
-This is an optional module for the Phoebus Olog electronic logbook service, see https://github.com/Olog/phoebus-olog. Its purpose is to send an email when a log is sent based on a list of emails mapped to the logbook entry's tag. 
+This is an optional module for the Phoebus Olog electronic logbook service, see https://github.com/Olog/phoebus-olog. Its purpose is to send an email when a log is sent based on a list of emails mapped to the logbook entry's tag.
 
 The module uses Simple Java Mail to send emails (Email java library: https://www.simplejavamail.org/).
 
@@ -9,7 +9,9 @@ The module uses Simple Java Mail to send emails (Email java library: https://www
 #### Add these to phoebus olog:
 
 pom.xml
-```
+
+```xml
+<!-- Email Notifier Module -->
 <dependency>
     <groupId>org.phoebus</groupId>
     <artifactId>olog-email-notifier-module</artifactId>
@@ -21,24 +23,32 @@ pom.xml
     <version>2.1.3</version>
 </dependency>
 <dependency>
-    <groupId>com.sun.mail</groupId>
-    <artifactId>jakarta.mail</artifactId>
-    <version>2.0.1</version>
+    <groupId>jakarta.mail</groupId>
+    <artifactId>jakarta.mail-api</artifactId>
+    <version>2.1.3</version>
+</dependency>
+<dependency>
+    <groupId>org.eclipse.angus</groupId>
+    <artifactId>angus-mail</artifactId>
+    <version>2.0.3</version>
 </dependency>
 ```
 
 Example tagsToEmails.json
-```
+
+```json
 {
-    "tagsToEmails": 
+    "tagsToEmails":
     {
       "tag1": ["email1@example.com"],
       "tag2": ["email2@example.com", "email3@example.com"]
     }
-}  
+}
 ```
+
 Add the following to olog application.properties
 Properties file:
+
 ```
 olog.tagsToEmailsFilePath=/pathToTagsToEmails.json
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pom.xml
 <dependency>
     <groupId>org.phoebus</groupId>
     <artifactId>olog-email-notifier-module</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
 </dependency>
 <dependency>
     <groupId>jakarta.activation</groupId>

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pom.xml
 <dependency>
     <groupId>org.phoebus</groupId>
     <artifactId>olog-email-notifier-module</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
 </dependency>
 <dependency>
     <groupId>jakarta.activation</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.phoebus</groupId>
@@ -22,25 +23,25 @@
       <version>4.7.7</version>
     </dependency>
     <dependency>
-        <groupId>org.simplejavamail</groupId>
-        <artifactId>simple-java-mail</artifactId>
-        <version>8.11.2</version>
+      <groupId>org.simplejavamail</groupId>
+      <artifactId>simple-java-mail</artifactId>
+      <version>8.11.2</version>
     </dependency>
     <dependency>
-        <groupId>org.simplejavamail</groupId>
-        <artifactId>spring-module</artifactId>
-        <version>8.11.2</version>
+      <groupId>org.simplejavamail</groupId>
+      <artifactId>spring-module</artifactId>
+      <version>8.11.2</version>
     </dependency>
     <dependency>
-        <groupId>jakarta.activation</groupId>
-        <artifactId>jakarta.activation-api</artifactId>
-        <version>2.1.3</version>
+      <groupId>jakarta.activation</groupId>
+      <artifactId>jakarta.activation-api</artifactId>
+      <version>2.1.3</version>
     </dependency>
     <dependency>
       <groupId>com.sun.mail</groupId>
       <artifactId>jakarta.mail</artifactId>
       <version>2.0.1</version>
-  </dependency>
+    </dependency>
     <dependency>
       <groupId>com.google.auto.service</groupId>
       <artifactId>auto-service</artifactId>
@@ -61,7 +62,7 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>5.21.0</version>
-    <scope>test</scope>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
@@ -81,14 +82,17 @@
   </dependencies>
 
   <build>
-    <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+    <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to
+      parent pom) -->
       <plugins>
-        <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
+        <!-- clean lifecycle, see
+        https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
         <plugin>
           <artifactId>maven-clean-plugin</artifactId>
           <version>3.1.0</version>
         </plugin>
-        <!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
+        <!-- default lifecycle, jar packaging: see
+        https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
         <plugin>
           <artifactId>maven-resources-plugin</artifactId>
           <version>3.0.2</version>
@@ -113,7 +117,8 @@
           <artifactId>maven-deploy-plugin</artifactId>
           <version>2.8.2</version>
         </plugin>
-        <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
+        <!-- site lifecycle, see
+        https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
         <plugin>
           <artifactId>maven-site-plugin</artifactId>
           <version>3.7.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -38,9 +38,9 @@
       <version>2.1.3</version>
     </dependency>
     <dependency>
-      <groupId>com.sun.mail</groupId>
-      <artifactId>jakarta.mail</artifactId>
-      <version>2.0.1</version>
+      <groupId>org.eclipse.angus</groupId>
+      <artifactId>angus-mail</artifactId>
+      <version>2.0.3</version>
     </dependency>
     <dependency>
       <groupId>com.google.auto.service</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -60,14 +60,8 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>5.12.0</version>
+      <version>5.21.0</version>
     <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
-      <version>5.2.0</version>
-      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>org.phoebus</groupId>
       <artifactId>service-olog</artifactId>
-      <version>4.7.7</version>
+      <version>5.1.2</version>
     </dependency>
     <dependency>
       <groupId>org.simplejavamail</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.phoebus</groupId>
   <artifactId>olog-email-notifier-module</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>1.1.0</version>
   <name>Olog Email Notifier Module</name>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.phoebus</groupId>
   <artifactId>olog-email-notifier-module</artifactId>
-  <version>1.1.0</version>
+  <version>1.2.0</version>
   <name>Olog Email Notifier Module</name>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.phoebus</groupId>
   <artifactId>olog-email-notifier-module</artifactId>
-  <version>1.2.0</version>
+  <version>1.2.1</version>
   <name>Olog Email Notifier Module</name>
 
 
@@ -82,7 +81,7 @@
   </dependencies>
 
   <build>
-    <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to
+    <pluginManagement>      <!-- lock down plugins versions to avoid using Maven defaults (may be moved to
       parent pom) -->
       <plugins>
         <!-- clean lifecycle, see

--- a/src/main/java/org/phoebus/olog/email/EmailNotifier.java
+++ b/src/main/java/org/phoebus/olog/email/EmailNotifier.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.HashMap;
 
 @AutoService(LogEntryNotifier.class)
 @Component
@@ -37,7 +38,7 @@ public class EmailNotifier implements LogEntryNotifier {
     @Autowired
     private Mailer mailer;
 
-    private Map<String,List<String>> tagEmailMap;
+    private Map<String,List<String>> tagEmailMap = new HashMap<>();
 
     @Override
     public void notify(Log log) {
@@ -75,7 +76,9 @@ public class EmailNotifier implements LogEntryNotifier {
                 if (tag.getState() == State.Active) {
                     String tagName = tag.getName();
                     tagNames.add(tagName);
-                    emailList.addAll(tagEmailMap.get(tagName));
+                    if (tagEmailMap.get(tagName) != null) {
+                        emailList.addAll(tagEmailMap.get(tagName));
+                    }
                 }
             }
             Email logbookEmail = createLogEmail(emailList, senderName, senderEmail, logTitle, log.getDescription(), tagNames);

--- a/src/main/java/org/phoebus/olog/email/EmailNotifier.java
+++ b/src/main/java/org/phoebus/olog/email/EmailNotifier.java
@@ -1,7 +1,21 @@
 package org.phoebus.olog.email;
 
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
 import org.phoebus.olog.entity.Attachment;
 import org.phoebus.olog.entity.Log;
+import org.phoebus.olog.entity.State;
+import org.phoebus.olog.entity.Tag;
 import org.phoebus.olog.notification.LogEntryNotifier;
 import org.simplejavamail.api.email.AttachmentResource;
 import org.simplejavamail.api.email.Email;
@@ -18,21 +32,6 @@ import com.google.auto.service.AutoService;
 
 import jakarta.activation.DataSource;
 import jakarta.mail.util.ByteArrayDataSource;
-
-import org.phoebus.olog.entity.Tag;
-import org.phoebus.olog.entity.State;
-
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.SortedSet;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.stream.Collectors;
-import java.util.HashMap;
 
 @AutoService(LogEntryNotifier.class)
 @Component

--- a/src/main/java/org/phoebus/olog/email/EmailNotifier.java
+++ b/src/main/java/org/phoebus/olog/email/EmailNotifier.java
@@ -55,6 +55,7 @@ public class EmailNotifier implements LogEntryNotifier {
         List<String> tagNames = new ArrayList<>();
 
         String logTitle = log.getTitle();
+        String owner = log.getOwner();
         String senderEmail = ConfigLoader.getStringProperty(Property.DEFAULT_FROM_ADDRESS);
         String senderName = ConfigLoader.getStringProperty(Property.DEFAULT_FROM_NAME);
 
@@ -113,7 +114,8 @@ public class EmailNotifier implements LogEntryNotifier {
                     }
                 }
             }
-            Email logbookEmail = createLogEmail(emailList, senderName, senderEmail, logTitle, log.getDescription(),
+            Email logbookEmail = createLogEmail(emailList, senderName, senderEmail, owner, logTitle,
+                    log.getDescription(),
                     tagNames, attachmentResources);
             if (!emailList.isEmpty()) {
                 logger.log(Level.INFO, "Email being sent to: " + emailList);
@@ -126,12 +128,12 @@ public class EmailNotifier implements LogEntryNotifier {
         }
     }
 
-    public Email createLogEmail(List<String> emailList, String senderName, String senderEmail, String subject,
-            String body, List<String> tagNames, List<AttachmentResource> attachmentList) {
+    public Email createLogEmail(List<String> emailList, String senderName, String senderEmail, String owner,
+            String subject, String body, List<String> tagNames, List<AttachmentResource> attachmentList) {
         return EmailBuilder.startingBlank()
                 .from(senderName, senderEmail)
                 .toMultiple(emailList)
-                .withSubject(subject)
+                .withSubject("[" + owner + "] " + subject)
                 .withPlainText(tagNames.toString())
                 .withPlainText(body)
                 .withAttachments(attachmentList)

--- a/src/main/java/org/phoebus/olog/email/EmailNotifier.java
+++ b/src/main/java/org/phoebus/olog/email/EmailNotifier.java
@@ -131,9 +131,9 @@ public class EmailNotifier implements LogEntryNotifier {
     public Email createLogEmail(List<String> emailList, String senderName, String senderEmail, String owner,
             String subject, String body, List<String> tagNames, List<AttachmentResource> attachmentList) {
         return EmailBuilder.startingBlank()
-                .from(senderName, senderEmail)
+                .from(senderName + " [" + owner + "]", senderEmail)
                 .toMultiple(emailList)
-                .withSubject("[" + owner + "] " + subject)
+                .withSubject(subject)
                 .withPlainText(tagNames.toString())
                 .withPlainText(body)
                 .withAttachments(attachmentList)

--- a/src/main/java/org/phoebus/olog/email/TagEmailMapPreferences.java
+++ b/src/main/java/org/phoebus/olog/email/TagEmailMapPreferences.java
@@ -1,6 +1,7 @@
 package org.phoebus.olog.email;
 
 import java.io.File;
+import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -8,7 +9,6 @@ import java.util.logging.Logger;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /** Preference settings for tag to email list

--- a/src/test/java/org/phoebus/olog/email/EmailNotifierTest.java
+++ b/src/test/java/org/phoebus/olog/email/EmailNotifierTest.java
@@ -1,7 +1,12 @@
 package org.phoebus.olog.email;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -11,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -18,15 +24,13 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
 import org.phoebus.olog.entity.Log;
-import org.phoebus.olog.entity.Tag;
 import org.phoebus.olog.entity.State;
+import org.phoebus.olog.entity.Tag;
+import org.simplejavamail.MailException;
 import org.simplejavamail.api.email.Email;
 import org.simplejavamail.api.mailer.Mailer;
 import org.simplejavamail.config.ConfigLoader;
 import org.simplejavamail.config.ConfigLoader.Property;
-import org.junit.Assert; 
-
-import org.simplejavamail.MailException;
 
 public class EmailNotifierTest {
 

--- a/src/test/java/org/phoebus/olog/email/TagEmailMapPreferencesTest.java
+++ b/src/test/java/org/phoebus/olog/email/TagEmailMapPreferencesTest.java
@@ -1,11 +1,14 @@
 package org.phoebus.olog.email;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 public class TagEmailMapPreferencesTest {
 


### PR DESCRIPTION
Hi,
On our project we would like to use this module. Unfortunately there were some broken dependencies.

This PR:
- replace the `com.sun.mail` package with the `org.eclipse.angus` one
- update the `README.md` with the new dependencies to add to the olog's `pom.xml`
- sort imports
- add support for attachments as requested in #2 (it is an interesting feature)
- add tests on the attachment section
- prepend "[<owner>]" in the email's subject
- update the version from 1.0 to 1.2.0

I'm not a Java developer and, since this version currently works as it is for our use case, if changes are needed, we would appreciate them coming directly from the main developers.

Regards,
Giovanni

PS a side note regarding the attachments improvement. **A fix on the olog service is needed**. In fact, when sending the data to the email-notifier, the olog-service does not add the attachments. The email notifier still works but the attchments are missing. I already implemented a fix on this behavior (on top of v5.1.2) on my fork https://github.com/giosava94/phoebus-olog (branch fix-notify-with-attachment).